### PR TITLE
feat: Add FTP result and error types

### DIFF
--- a/src/gftp/result.gleam
+++ b/src/gftp/result.gleam
@@ -1,0 +1,45 @@
+//// The result module exposes the Result type and errors related to gftp.
+
+import gftp/response.{type Response}
+import mug
+
+/// The FtpResult type is a Result that can contain either a successful value of type a or an FtpError.
+pub type FtpResult(a) =
+  Result(a, FtpError)
+
+pub type FtpError {
+  /// Connection error
+  ConnectionError(mug.ConnectError)
+  /// There was an error with the secure stream
+  SecureError(String)
+  /// Unexpected response from remote. The command expected a certain response, but got another one.
+  /// This means the ftp server refused to perform your request or there was an error while processing it.
+  /// Contains the response data.
+  UnexpectedResponse(Response)
+  /// The response syntax is invalid
+  BadResponse
+  /// The address provided was invalid
+  Socket(mug.Error)
+  /// Data connection is already open. You can't open more than one data connection at a time.
+  DataConnectionAlreadyOpen
+}
+
+fn connection_error_to_string(e: mug.ConnectError) -> String {
+  case e {
+    mug.ConnectFailedIpv4(e) -> mug.describe_error(e)
+    mug.ConnectFailedIpv6(e) -> mug.describe_error(e)
+    mug.ConnectFailedBoth(e, _) -> mug.describe_error(e)
+  }
+}
+
+/// The description function takes an FtpError and returns a human-readable string describing the error.
+pub fn describe_error(err: FtpError) -> String {
+  case err {
+    ConnectionError(e) -> "Connection error: " <> connection_error_to_string(e)
+    SecureError(e) -> "Secure error: " <> e
+    UnexpectedResponse(r) -> "Unexpected response: " <> response.describe(r)
+    BadResponse -> "Bad response syntax"
+    Socket(e) -> "Socket error: " <> mug.describe_error(e)
+    DataConnectionAlreadyOpen -> "Data connection is already open"
+  }
+}

--- a/test/gftp/result_test.gleam
+++ b/test/gftp/result_test.gleam
@@ -1,0 +1,58 @@
+import gftp/response.{Response}
+import gftp/result
+import gftp/status
+import gleeunit/should
+import mug
+
+pub fn describe_error_connection_error_ipv4_test() {
+  result.ConnectionError(mug.ConnectFailedIpv4(mug.Econnrefused))
+  |> result.describe_error
+  |> should.equal("Connection error: Connection refused")
+}
+
+pub fn describe_error_connection_error_ipv6_test() {
+  result.ConnectionError(mug.ConnectFailedIpv6(mug.Timeout))
+  |> result.describe_error
+  |> should.equal("Connection error: Operation timed out")
+}
+
+pub fn describe_error_connection_error_both_test() {
+  result.ConnectionError(mug.ConnectFailedBoth(
+    ipv4: mug.Econnrefused,
+    ipv6: mug.Ehostunreach,
+  ))
+  |> result.describe_error
+  |> should.equal("Connection error: Connection refused")
+}
+
+pub fn describe_error_secure_error_test() {
+  result.SecureError("TLS handshake failed")
+  |> result.describe_error
+  |> should.equal("Secure error: TLS handshake failed")
+}
+
+pub fn describe_error_unexpected_response_test() {
+  result.UnexpectedResponse(
+    Response(code: status.NotLoggedIn, message: <<"Login required":utf8>>),
+  )
+  |> result.describe_error
+  |> should.equal("Unexpected response: [user not logged in] Login required")
+}
+
+pub fn describe_error_bad_response_test() {
+  result.BadResponse
+  |> result.describe_error
+  |> should.equal("Bad response syntax")
+}
+
+pub fn describe_error_socket_error_test() {
+  result.Socket(mug.Econnreset)
+  |> result.describe_error
+  |> should.equal("Socket error: Connection reset by peer")
+}
+
+pub fn describe_error_data_connection_already_open_test() {
+  result.DataConnectionAlreadyOpen
+  |> result.describe_error
+  |> should.equal("Data connection is already open")
+}


### PR DESCRIPTION
## Summary

- Add `FtpResult(a)` type alias and `FtpError` type with variants for connection, secure, unexpected response, bad response, socket, and data connection errors
- Add `describe_error` function for human-readable error descriptions
- Add unit tests covering all `FtpError` variants

## Test plan

- [x] All 8 new tests in `test/gftp/result_test.gleam` pass
- [x] Full test suite passes (166 tests)
- [x] Code formatted with `gleam format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)