### PR TITLE
feat: add DataStream type with TCP/TLS support

### DIFF
--- a/src/gftp/stream.gleam
+++ b/src/gftp/stream.gleam
@@ -1,0 +1,66 @@
+//// The stream module provides an interface for working with a network stream, which can either be a TCP stream or a TLS stream.
+//// It abstracts away the differences between the two types of streams and provides a unified interface for reading and writing data.
+
+import kafein.{type WrapOptions}
+import mug
+
+/// Workaround for kafein bug: patches the WrapOptions to convert the
+/// server_name_indication from a binary to a charlist before kafein.wrap
+/// processes it. Remove once kafein fixes this upstream.
+/// 
+/// See <https://github.com/fuzzko/kafein/issues/1>
+@external(erlang, "stream_ffi", "patch_wrap_options")
+fn patch_wrap_options(options: WrapOptions) -> WrapOptions
+
+/// Data Stream used for communications. It can be both of type Tcp in case of plain communication or Ssl in case of FTPS
+pub type DataStream {
+  Ssl(kafein.SslSocket)
+  Tcp(mug.Socket)
+}
+
+/// Receive a message from the peer.
+/// 
+/// Errors if the socket is closed, if the timeout is reached, or if any other error occurs during the receive operation.
+/// The error is returned as a [`mug.Error`]. In case of success, it returns the received data as a `BitArray`.
+pub fn receive(stream: DataStream, timeout: Int) -> Result(BitArray, mug.Error) {
+  case stream {
+    Ssl(ssl_socket) -> kafein.receive(ssl_socket, timeout)
+    Tcp(tcp_socket) -> mug.receive(tcp_socket, timeout)
+  }
+}
+
+/// Sends data over the provided stream.
+/// It handles both SSL and TCP streams, abstracting away the differences between them.
+/// 
+/// Returns a Result indicating success (`Nil`) or an error ([`mug.Error`]) if the send operation fails.
+pub fn send(stream: DataStream, data: BitArray) -> Result(Nil, mug.Error) {
+  case stream {
+    Ssl(ssl_socket) -> kafein.send(ssl_socket, data)
+    Tcp(tcp_socket) -> mug.send(tcp_socket, data)
+  }
+}
+
+/// Upgrades a TCP stream to an SSL stream using the provided options. If the stream is already an SSL stream, it returns it as is.
+pub fn upgrade_to_ssl(
+  stream: DataStream,
+  options: WrapOptions,
+) -> Result(DataStream, kafein.Error) {
+  case stream {
+    Ssl(_) -> Ok(stream)
+    // Already an SSL stream, return as is
+    Tcp(tcp_socket) ->
+      case kafein.wrap(patch_wrap_options(options), tcp_socket) {
+        Ok(ssl_socket) -> Ok(Ssl(ssl_socket))
+        Error(e) -> Error(e)
+      }
+  }
+}
+
+/// Shuts down the provided stream, whether it's an SSL or TCP stream.
+/// It abstracts away the differences between the two types of streams and provides a unified interface for shutting them down.
+pub fn shutdown(stream: DataStream) -> Result(Nil, mug.Error) {
+  case stream {
+    Ssl(ssl_socket) -> kafein.shutdown(ssl_socket)
+    Tcp(tcp_socket) -> mug.shutdown(tcp_socket)
+  }
+}

--- a/src/gftp/stream_ffi.erl
+++ b/src/gftp/stream_ffi.erl
@@ -1,0 +1,16 @@
+-module(stream_ffi).
+
+-export([patch_wrap_options/1]).
+
+%% Workaround for kafein bug: kafein passes the server_name_indication as a
+%% binary to ssl:connect, but Erlang's ssl module expects a charlist.
+%% This function patches the WrapOptions tuple (element 11) to convert
+%% the binary hostname to a charlist before kafein.wrap processes it.
+%% See: https://github.com/fuzzko/kafein/issues/1
+patch_wrap_options(Options) ->
+    case erlang:element(11, Options) of
+        {some, Name} when is_binary(Name) ->
+            erlang:setelement(11, Options, {some, binary_to_list(Name)});
+        _ ->
+            Options
+    end.

--- a/test/gftp/stream_integration_test.gleam
+++ b/test/gftp/stream_integration_test.gleam
@@ -1,0 +1,112 @@
+import gftp/stream.{Ssl, Tcp}
+import gleam/bit_array
+import gleam/string
+import gleeunit/should
+import kafein
+import mug
+
+@external(erlang, "stream_test_ffi", "get_env")
+fn get_env(name: String) -> Result(String, Nil)
+
+fn require_integration() -> Bool {
+  case get_env("GFTP_INTEGRATION_TESTS") {
+    Ok(_) -> True
+    Error(_) -> False
+  }
+}
+
+fn connect_tcp(host: String, port: Int) -> mug.Socket {
+  let assert Ok(socket) =
+    mug.new(host, port: port)
+    |> mug.timeout(milliseconds: 10_000)
+    |> mug.connect()
+  socket
+}
+
+fn ssl_options(hostname: String) -> kafein.WrapOptions {
+  kafein.default_options
+  |> kafein.verify(verify_type: kafein.VerifyNone)
+  |> kafein.server_name_indication(hostname: hostname)
+}
+
+pub fn integration_upgrade_to_ssl_test() {
+  case require_integration() {
+    False -> Nil
+    True -> {
+      let host = "example.com"
+      let tcp_socket = connect_tcp(host, 443)
+      let tcp_stream = Tcp(tcp_socket)
+
+      // Upgrade TCP to SSL
+      let assert Ok(ssl_stream) =
+        stream.upgrade_to_ssl(tcp_stream, ssl_options(host))
+
+      // Verify it's now an Ssl variant
+      case ssl_stream {
+        Ssl(_) -> Nil
+        Tcp(_) -> panic as "expected Ssl variant after upgrade"
+      }
+
+      // Upgrading an already-SSL stream should return it unchanged
+      let assert Ok(still_ssl) =
+        stream.upgrade_to_ssl(ssl_stream, ssl_options(host))
+      case still_ssl {
+        Ssl(_) -> Nil
+        Tcp(_) -> panic as "expected Ssl variant to remain after double upgrade"
+      }
+
+      let _ = stream.shutdown(ssl_stream)
+      Nil
+    }
+  }
+}
+
+pub fn integration_send_receive_ssl_test() {
+  case require_integration() {
+    False -> Nil
+    True -> {
+      let host = "example.com"
+      let tcp_socket = connect_tcp(host, 443)
+      let tcp_stream = Tcp(tcp_socket)
+
+      let assert Ok(ssl_stream) =
+        stream.upgrade_to_ssl(tcp_stream, ssl_options(host))
+
+      // Send an HTTP GET request
+      let request =
+        "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n"
+      stream.send(ssl_stream, <<request:utf8>>)
+      |> should.be_ok()
+
+      // Receive the response
+      let response_bytes =
+        stream.receive(ssl_stream, 10_000)
+        |> should.be_ok()
+
+      // Verify it looks like an HTTP response
+      let assert Ok(response_text) = bit_array.to_string(response_bytes)
+      string.starts_with(response_text, "HTTP/1.1")
+      |> should.be_true()
+
+      let _ = stream.shutdown(ssl_stream)
+      Nil
+    }
+  }
+}
+
+pub fn integration_shutdown_ssl_test() {
+  case require_integration() {
+    False -> Nil
+    True -> {
+      let host = "example.com"
+      let tcp_socket = connect_tcp(host, 443)
+      let tcp_stream = Tcp(tcp_socket)
+
+      let assert Ok(ssl_stream) =
+        stream.upgrade_to_ssl(tcp_stream, ssl_options(host))
+
+      stream.shutdown(ssl_stream)
+      |> should.be_ok()
+    }
+  }
+}

--- a/test/gftp/stream_test.gleam
+++ b/test/gftp/stream_test.gleam
@@ -1,0 +1,104 @@
+import gftp/stream.{Tcp}
+import gleeunit/should
+import mug
+
+// Opaque types for server-side sockets (gen_tcp)
+type ListenSocket
+
+type ServerSocket
+
+@external(erlang, "stream_test_ffi", "listen")
+fn listen() -> ListenSocket
+
+@external(erlang, "stream_test_ffi", "listen_port")
+fn listen_port(socket: ListenSocket) -> Int
+
+@external(erlang, "stream_test_ffi", "accept")
+fn accept(socket: ListenSocket) -> ServerSocket
+
+@external(erlang, "stream_test_ffi", "server_send")
+fn server_send(socket: ServerSocket, data: BitArray) -> Nil
+
+@external(erlang, "stream_test_ffi", "server_recv")
+fn server_recv(socket: ServerSocket, timeout: Int) -> Result(BitArray, Nil)
+
+@external(erlang, "stream_test_ffi", "close_listen")
+fn close_listen(socket: ListenSocket) -> Nil
+
+@external(erlang, "stream_test_ffi", "close_server")
+fn close_server(socket: ServerSocket) -> Nil
+
+fn connect_client(port: Int) -> mug.Socket {
+  let assert Ok(socket) =
+    mug.new("127.0.0.1", port: port)
+    |> mug.timeout(milliseconds: 5000)
+    |> mug.ip_version_preference(mug.Ipv4Only)
+    |> mug.connect()
+  socket
+}
+
+pub fn receive_tcp_test() {
+  let listen_socket = listen()
+  let port = listen_port(listen_socket)
+  let client_socket = connect_client(port)
+  let server_socket = accept(listen_socket)
+
+  server_send(server_socket, <<"hello world":utf8>>)
+
+  stream.receive(Tcp(client_socket), 5000)
+  |> should.be_ok()
+  |> should.equal(<<"hello world":utf8>>)
+
+  close_server(server_socket)
+  close_listen(listen_socket)
+  let _ = stream.shutdown(Tcp(client_socket))
+  Nil
+}
+
+pub fn send_tcp_test() {
+  let listen_socket = listen()
+  let port = listen_port(listen_socket)
+  let client_socket = connect_client(port)
+  let server_socket = accept(listen_socket)
+
+  stream.send(Tcp(client_socket), <<"hello from client":utf8>>)
+  |> should.be_ok()
+
+  server_recv(server_socket, 5000)
+  |> should.be_ok()
+  |> should.equal(<<"hello from client":utf8>>)
+
+  close_server(server_socket)
+  close_listen(listen_socket)
+  let _ = stream.shutdown(Tcp(client_socket))
+  Nil
+}
+
+pub fn shutdown_tcp_test() {
+  let listen_socket = listen()
+  let port = listen_port(listen_socket)
+  let client_socket = connect_client(port)
+  let server_socket = accept(listen_socket)
+
+  stream.shutdown(Tcp(client_socket))
+  |> should.be_ok()
+
+  close_server(server_socket)
+  close_listen(listen_socket)
+}
+
+pub fn receive_tcp_timeout_test() {
+  let listen_socket = listen()
+  let port = listen_port(listen_socket)
+  let client_socket = connect_client(port)
+  let server_socket = accept(listen_socket)
+
+  // No data sent, so receive should timeout
+  stream.receive(Tcp(client_socket), 100)
+  |> should.be_error()
+
+  close_server(server_socket)
+  close_listen(listen_socket)
+  let _ = stream.shutdown(Tcp(client_socket))
+  Nil
+}

--- a/test/gftp/stream_test_ffi.erl
+++ b/test/gftp/stream_test_ffi.erl
@@ -1,0 +1,39 @@
+-module(stream_test_ffi).
+
+-export([listen/0, listen_port/1, accept/1, server_send/2, server_recv/2, close_listen/1, close_server/1, get_env/1]).
+
+listen() ->
+    {ok, ListenSocket} = gen_tcp:listen(0, [binary, {active, false}, {reuseaddr, true}, {ip, {127, 0, 0, 1}}]),
+    ListenSocket.
+
+listen_port(ListenSocket) ->
+    {ok, Port} = inet:port(ListenSocket),
+    Port.
+
+accept(ListenSocket) ->
+    {ok, Socket} = gen_tcp:accept(ListenSocket, 5000),
+    Socket.
+
+server_send(Socket, Data) ->
+    ok = gen_tcp:send(Socket, Data),
+    nil.
+
+server_recv(Socket, Timeout) ->
+    case gen_tcp:recv(Socket, 0, Timeout) of
+        {ok, Data} -> {ok, Data};
+        {error, _Reason} -> {error, nil}
+    end.
+
+close_listen(Socket) ->
+    gen_tcp:close(Socket),
+    nil.
+
+close_server(Socket) ->
+    gen_tcp:close(Socket),
+    nil.
+
+get_env(Name) ->
+    case os:getenv(binary_to_list(Name)) of
+        false -> {error, nil};
+        Value -> {ok, list_to_binary(Value)}
+    end.


### PR DESCRIPTION
## Summary
- Add `stream` module providing a unified `DataStream` type that abstracts TCP (`mug`) and TLS (`kafein`) sockets with `receive`, `send`, `shutdown`, and `upgrade_to_ssl` functions
- Include a workaround for a [kafein SNI bug](https://github.com/fuzzko/kafein/issues/1) where `server_name_indication` is passed as a binary instead of a charlist to Erlang's `ssl:connect`, causing a `badarg` crash
- Add unit tests for the TCP path using a local `gen_tcp` test server via Erlang FFI
- Add integration tests for the TLS path against `example.com:443`, gated behind the `GFTP_INTEGRATION_TESTS` env var

## Test plan
- [x] `gleam test` — all 248 tests pass (integration tests skipped)
- [x] `GFTP_INTEGRATION_TESTS=1 gleam test` — all 248 tests pass including TLS integration
- [x] `gleam format --check src test` — formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)