### PR TITLE
feat: implement FEAT command to retrieve server features

### DIFF
--- a/src/gftp/command/feat.gleam
+++ b/src/gftp/command/feat.gleam
@@ -1,0 +1,54 @@
+//// This module exposes the FEAT command types
+
+import gftp/result.{type FtpResult} as ftp_result
+import gleam/dict
+import gleam/option.{type Option, None, Some}
+import gleam/result
+import gleam/string
+
+/// The features supported by the server, as returned by the FEAT command.
+/// 
+/// A feat has a key representing the name of the feature, and an optional value representing any parameters for that feature.
+pub type Features =
+  dict.Dict(String, Option(String))
+
+/// Returns whether the given line is the last line of a FEAT response, which starts with "211 ".
+pub fn is_last_line(line: String) -> Bool {
+  string.starts_with(line, "211 ")
+}
+
+/// Parses the lines of a FEAT response into a `Features` dictionary.
+pub fn parse_features(lines: List(String)) -> FtpResult(Features) {
+  parse_feature_loop(dict.new(), lines)
+}
+
+/// Helper function to recursively parse the lines of a FEAT response into a `Features` dictionary.
+fn parse_feature_loop(acc: Features, lines: List(String)) -> FtpResult(Features) {
+  case lines {
+    [] -> Ok(acc)
+    [line, ..rest] -> {
+      use #(key, value) <- result.try(parse_feature(line))
+      parse_feature_loop(dict.insert(acc, key, value), rest)
+    }
+  }
+}
+
+/// Parses a single line of a FEAT response into a key-value pair.
+fn parse_feature(line: String) -> FtpResult(#(String, Option(String))) {
+  use trimmed_line <- result.try(trim_line(line))
+  let tokens = string.split(trimmed_line, " ")
+
+  case tokens {
+    [] -> Error(ftp_result.BadResponse)
+    [key] -> Ok(#(key, None))
+    [key, ..rest] -> Ok(#(key, Some(string.join(rest, " "))))
+  }
+}
+
+/// Checks if the given line starts with a space, and if so, trims it. Otherwise, returns an error.
+fn trim_line(line: String) -> FtpResult(String) {
+  case string.starts_with(line, " ") {
+    True -> Ok(string.trim(line))
+    False -> Error(ftp_result.BadResponse)
+  }
+}

--- a/test/gftp/command/feat_test.gleam
+++ b/test/gftp/command/feat_test.gleam
@@ -1,0 +1,55 @@
+import gftp/command/feat
+import gleam/dict
+import gleam/option.{None, Some}
+import gleeunit/should
+
+// --- is_last_line ---
+
+pub fn is_last_line_with_closing_line_test() {
+  feat.is_last_line("211 End") |> should.be_true
+}
+
+pub fn is_last_line_with_header_line_test() {
+  feat.is_last_line("211-Extensions supported:") |> should.be_false
+}
+
+pub fn is_last_line_with_feature_line_test() {
+  feat.is_last_line(" AUTH TLS") |> should.be_false
+}
+
+// --- parse_features ---
+
+pub fn parse_features_empty_list_test() {
+  feat.parse_features([])
+  |> should.equal(Ok(dict.new()))
+}
+
+pub fn parse_features_single_feature_without_value_test() {
+  feat.parse_features([" UTF8"])
+  |> should.equal(Ok(dict.from_list([#("UTF8", None)])))
+}
+
+pub fn parse_features_single_feature_with_value_test() {
+  feat.parse_features([" REST STREAM"])
+  |> should.equal(Ok(dict.from_list([#("REST", Some("STREAM"))])))
+}
+
+pub fn parse_features_multiple_features_test() {
+  feat.parse_features([" AUTH TLS", " PBSZ", " SIZE", " REST STREAM", " UTF8"])
+  |> should.equal(
+    Ok(
+      dict.from_list([
+        #("AUTH", Some("TLS")),
+        #("PBSZ", None),
+        #("SIZE", None),
+        #("REST", Some("STREAM")),
+        #("UTF8", None),
+      ]),
+    ),
+  )
+}
+
+pub fn parse_features_line_without_leading_space_test() {
+  feat.parse_features(["AUTH TLS"])
+  |> should.be_error
+}

--- a/test/gftp_integration_test.gleam
+++ b/test/gftp_integration_test.gleam
@@ -5,6 +5,7 @@ import gftp/result as ftp_result
 import gftp/status
 import gftp/stream
 import gleam/bit_array
+import gleam/dict
 import gleam/list
 import gleam/option.{None, Some}
 import gleam/result
@@ -319,6 +320,24 @@ pub fn nlst_test() {
 // mlsd_test disabled: vsftpd in test container doesn't support MLSD
 
 // mlst_test disabled: vsftpd in test container doesn't support MLST
+
+// --- FEAT command tests ---
+
+pub fn feat_test() {
+  with_ftp_connection(fn(client) {
+    let assert Ok(features) = gftp.feat(client)
+    // vsftpd supports these features
+    dict.has_key(features, "EPRT") |> should.be_true
+    dict.has_key(features, "EPSV") |> should.be_true
+    dict.has_key(features, "MDTM") |> should.be_true
+    dict.has_key(features, "PASV") |> should.be_true
+    dict.has_key(features, "SIZE") |> should.be_true
+    dict.has_key(features, "UTF8") |> should.be_true
+    // REST has a value "STREAM"
+    dict.get(features, "REST") |> should.equal(Ok(Some("STREAM")))
+    Nil
+  })
+}
 
 // --- Misc command tests ---
 


### PR DESCRIPTION
## Summary

- Add `feat` module (`src/gftp/command/feat.gleam`) for parsing FEAT responses into a `Features` dictionary (`Dict(String, Option(String))`)
- Implement `feat` function in `gftp.gleam` that sends the FEAT command and correctly parses the multiline response body already consumed by `read_response`, instead of attempting to read additional lines from the socket
- Add unit tests for `is_last_line` and `parse_features` covering valid, empty, and error cases
- Add integration test verifying expected vsftpd features (EPRT, EPSV, MDTM, PASV, SIZE, UTF8, REST STREAM)

## Test plan

- [x] Unit tests pass (`gleam test -- --only feat_test`)
- [x] Integration test passes against Docker vsftpd container (`GFTP_INTEGRATION_TESTS=1 gleam test -- --only feat_test`)
- [x] Full test suite passes (291 tests)
- [x] Formatting check passes (`gleam format --check src test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)