### PR TITLE
fix: MLST and MLSD `unix.mode` should accept 4-digit octal modes

### DIFF
--- a/src/gftp/list.gleam
+++ b/src/gftp/list.gleam
@@ -143,7 +143,9 @@ fn parse_mlsd_mlst_permissions(
     |> string.split("")
     |> list.map(fn(token) { token |> int.base_parse(8) |> result.unwrap(or: 0) })
   case tokens {
-    [user, group, other] ->
+    // support both three-digit (user, group, other) and four-digit (setuid/setgid/ sticky + user, group, other) formats,
+    // ignoring the setuid/setgid/sticky bits if present (e.g. `755` or `0755` both parse to the same permissions).
+    [user, group, other] | [_, user, group, other] ->
       Ok(FilePermissions(
         owner: permission.from_int(user),
         group: permission.from_int(group),

--- a/test/gftp/list_test.gleam
+++ b/test/gftp/list_test.gleam
@@ -315,6 +315,17 @@ pub fn parse_mlsd_with_unix_mode_644_test() {
   )) = file.permissions(f)
 }
 
+pub fn parse_mlsd_with_unix_mode_4digits_test() {
+  let line =
+    "type=file;size=100;modify=20201105134600;unix.mode=0644; readme.txt"
+  let assert Ok(f) = list.parse_mlsd(line)
+  let assert Some(FilePermissions(
+    owner: PosixPermission(read: True, write: True, execute: False),
+    group: PosixPermission(read: True, write: False, execute: False),
+    others: PosixPermission(read: True, write: False, execute: False),
+  )) = file.permissions(f)
+}
+
 pub fn parse_mlsd_unknown_keys_ignored_test() {
   let line =
     "type=file;size=100;modify=20201105134600;unknown.key=value; test.txt"


### PR DESCRIPTION
THe `unix.mode` field on some server is returned with the setuid/setgid/sticky bits, so it may be either in format `755` or `0755` for instance. In the second case we ignore the first digit and take just the last three

closes #19