### PR TITLE
test: use testcontainers instead of manually setting containers up with docker commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           otp-version: "28"
           gleam-version: "1.14.0"
+          elixir-version: "1.19.5"
           rebar3-version: "3"
       - run: gleam deps download
       - name: gleam test

--- a/gleam.toml
+++ b/gleam.toml
@@ -18,3 +18,4 @@ mug = ">= 3.1.0 and < 4.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
+testcontainers_gleam = { git = "https://github.com/veeso/testcontainers-gleam.git", ref = "a9946491" }

--- a/gleam.toml
+++ b/gleam.toml
@@ -18,4 +18,5 @@ mug = ">= 3.1.0 and < 4.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
-testcontainers_gleam = { git = "https://github.com/veeso/testcontainers-gleam.git", ref = "a9946491" }
+testcontainers_gleam = ">= 2.0.0 and < 3.0.0"
+envoy = ">= 1.1.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -24,12 +24,13 @@ packages = [
   { name = "ssl_verify_fun", version = "1.1.7", build_tools = ["mix", "rebar3", "make"], requirements = [], otp_app = "ssl_verify_fun", source = "hex", outer_checksum = "FE4C190E8F37401D30167C8C405EDA19469F34577987C76DDE613E838BBC67F8" },
   { name = "tesla", version = "1.16.0", build_tools = ["mix"], requirements = ["castore", "exjsx", "finch", "fuse", "gun", "hackney", "ibrowse", "jason", "mime", "mint", "mox", "msgpax", "poison", "telemetry"], otp_app = "tesla", source = "hex", outer_checksum = "EB3BDFC0C6C8A23B4E3D86558E812E3577ACFF1CB4ACB6CFE2DA1985A1035B89" },
   { name = "testcontainers", version = "1.14.1", build_tools = ["mix"], requirements = ["ecto", "ecto_sql", "fs", "hackney", "jason", "tesla", "uniq"], otp_app = "testcontainers", source = "hex", outer_checksum = "4CFCA95679E50EB96CCC634386C919A0BE37B507275BDB5972CB022B6664A072" },
-  { name = "testcontainers_gleam", version = "2.0.0", build_tools = ["gleam"], requirements = ["envoy", "gleam_erlang", "gleam_stdlib", "testcontainers"], source = "git", repo = "https://github.com/veeso/testcontainers-gleam.git", commit = "a994649193082188e2a0688010e363179205a4e3" },
+  { name = "testcontainers_gleam", version = "2.0.0", build_tools = ["gleam"], requirements = ["envoy", "gleam_erlang", "gleam_stdlib", "testcontainers"], otp_app = "testcontainers_gleam", source = "hex", outer_checksum = "46518D5E5758D451728E306FC966A7B5B9AFC8E873BA4FA5A91999C10938A52C" },
   { name = "unicode_util_compat", version = "0.7.1", build_tools = ["rebar3"], requirements = [], otp_app = "unicode_util_compat", source = "hex", outer_checksum = "B3A917854CE3AE233619744AD1E0102E05673136776FB2FA76234F3E03B23642" },
   { name = "uniq", version = "0.6.2", build_tools = ["mix"], requirements = ["ecto"], otp_app = "uniq", source = "hex", outer_checksum = "95AA2A41EA331EF0A52D8ED12D3E730EF9AF9DBC30F40646E6AF334FBD7BC0FC" },
 ]
 
 [requirements]
+envoy = { version = ">= 1.1.0 and < 2.0.0" }
 gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_regexp = { version = ">= 1.1.1 and < 2.0.0" }
@@ -39,4 +40,4 @@ gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 gtempo = { version = ">= 7.2.4 and < 8.0.0" }
 kafein = { version = ">= 2.0.0 and < 3.0.0" }
 mug = { version = ">= 3.1.0 and < 4.0.0" }
-testcontainers_gleam = { git = "https://github.com/veeso/testcontainers-gleam.git", ref = "a9946491" }
+testcontainers_gleam = { version = ">= 2.0.0 and < 3.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,6 +2,9 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "certifi", version = "2.15.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "B147ED22CE71D72EAFDAD94F055165C1C182F61A2FF49DF28BCC71D1D5B94A60" },
+  { name = "envoy", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "850DA9D29D2E5987735872A2B5C81035146D7FE19EFC486129E44440D03FD832" },
+  { name = "fs", version = "11.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "DD00A61D89EAC01D16D3FC51D5B0EB5F0722EF8E3C1A3A547CD086957F3260A9" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
@@ -9,8 +12,21 @@ packages = [
   { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
   { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
   { name = "gtempo", version = "7.2.4", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "gleam_time"], otp_app = "gtempo", source = "hex", outer_checksum = "997964753BB7E9D9EA7023B9DB401871410D17C8ED8AC897CB9F7BFC33B277ED" },
+  { name = "hackney", version = "1.25.0", build_tools = ["rebar3"], requirements = ["certifi", "idna", "metrics", "mimerl", "parse_trans", "ssl_verify_fun", "unicode_util_compat"], otp_app = "hackney", source = "hex", outer_checksum = "7209BFD75FD1F42467211FF8F59EA74D6F2A9E81CBCEE95A56711EE79FD6B1D4" },
+  { name = "idna", version = "6.1.1", build_tools = ["rebar3"], requirements = ["unicode_util_compat"], otp_app = "idna", source = "hex", outer_checksum = "92376EB7894412ED19AC475E4A86F7B413C1B9FBB5BD16DCCD57934157944CEA" },
+  { name = "jason", version = "1.4.4", build_tools = ["mix"], requirements = ["decimal"], otp_app = "jason", source = "hex", outer_checksum = "C5EB0CAB91F094599F94D55BC63409236A8EC69A21A67814529E8D5F6CC90B3B" },
   { name = "kafein", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib", "mug"], otp_app = "kafein", source = "hex", outer_checksum = "9C0B8DFF32DF2CE6A9F9D739CF15F9FD5C88BB6CE2E70FB50FCE2BD91B50E4FA" },
+  { name = "metrics", version = "1.0.1", build_tools = ["rebar3"], requirements = [], otp_app = "metrics", source = "hex", outer_checksum = "69B09ADDDC4F74A40716AE54D140F93BEB0FB8978D8636EADED0C31B6F099F16" },
+  { name = "mime", version = "2.0.7", build_tools = ["mix"], requirements = [], otp_app = "mime", source = "hex", outer_checksum = "6171188E399EE16023FFC5B76CE445EB6D9672E2E241D2DF6050F3C771E80CCD" },
+  { name = "mimerl", version = "1.4.0", build_tools = ["rebar3"], requirements = [], otp_app = "mimerl", source = "hex", outer_checksum = "13AF15F9F68C65884ECCA3A3891D50A7B57D82152792F3E19D88650AA126B144" },
   { name = "mug", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "mug", source = "hex", outer_checksum = "C01279D98E40371DA23461774B63F0E3581B8F1396049D881B0C7EB32799D93F" },
+  { name = "parse_trans", version = "3.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "parse_trans", source = "hex", outer_checksum = "620A406CE75DADA827B82E453C19CF06776BE266F5A67CFF34E1EF2CBB60E49A" },
+  { name = "ssl_verify_fun", version = "1.1.7", build_tools = ["mix", "rebar3", "make"], requirements = [], otp_app = "ssl_verify_fun", source = "hex", outer_checksum = "FE4C190E8F37401D30167C8C405EDA19469F34577987C76DDE613E838BBC67F8" },
+  { name = "tesla", version = "1.16.0", build_tools = ["mix"], requirements = ["castore", "exjsx", "finch", "fuse", "gun", "hackney", "ibrowse", "jason", "mime", "mint", "mox", "msgpax", "poison", "telemetry"], otp_app = "tesla", source = "hex", outer_checksum = "EB3BDFC0C6C8A23B4E3D86558E812E3577ACFF1CB4ACB6CFE2DA1985A1035B89" },
+  { name = "testcontainers", version = "1.14.1", build_tools = ["mix"], requirements = ["ecto", "ecto_sql", "fs", "hackney", "jason", "tesla", "uniq"], otp_app = "testcontainers", source = "hex", outer_checksum = "4CFCA95679E50EB96CCC634386C919A0BE37B507275BDB5972CB022B6664A072" },
+  { name = "testcontainers_gleam", version = "2.0.0", build_tools = ["gleam"], requirements = ["envoy", "gleam_erlang", "gleam_stdlib", "testcontainers"], source = "git", repo = "https://github.com/veeso/testcontainers-gleam.git", commit = "a994649193082188e2a0688010e363179205a4e3" },
+  { name = "unicode_util_compat", version = "0.7.1", build_tools = ["rebar3"], requirements = [], otp_app = "unicode_util_compat", source = "hex", outer_checksum = "B3A917854CE3AE233619744AD1E0102E05673136776FB2FA76234F3E03B23642" },
+  { name = "uniq", version = "0.6.2", build_tools = ["mix"], requirements = ["ecto"], otp_app = "uniq", source = "hex", outer_checksum = "95AA2A41EA331EF0A52D8ED12D3E730EF9AF9DBC30F40646E6AF334FBD7BC0FC" },
 ]
 
 [requirements]
@@ -23,3 +39,4 @@ gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 gtempo = { version = ">= 7.2.4 and < 8.0.0" }
 kafein = { version = ">= 2.0.0 and < 3.0.0" }
 mug = { version = ">= 3.1.0 and < 4.0.0" }
+testcontainers_gleam = { git = "https://github.com/veeso/testcontainers-gleam.git", ref = "a9946491" }

--- a/test/gftp/stream_integration_test.gleam
+++ b/test/gftp/stream_integration_test.gleam
@@ -1,14 +1,12 @@
+import envoy
 import gftp/stream.{Ssl, Tcp}
 import gleam/bit_array
 import gleam/string
 import kafein
 import mug
 
-@external(erlang, "stream_test_ffi", "get_env")
-fn get_env(name: String) -> Result(String, Nil)
-
 fn require_integration() -> Bool {
-  case get_env("GFTP_INTEGRATION_TESTS") {
+  case envoy.get("GFTP_INTEGRATION_TESTS") {
     Ok(_) -> True
     Error(_) -> False
   }

--- a/test/gftp/stream_test_ffi.erl
+++ b/test/gftp/stream_test_ffi.erl
@@ -1,6 +1,6 @@
 -module(stream_test_ffi).
 
--export([listen/0, listen_port/1, accept/1, server_send/2, server_recv/2, close_listen/1, close_server/1, get_env/1]).
+-export([listen/0, listen_port/1, accept/1, server_send/2, server_recv/2, close_listen/1, close_server/1]).
 
 listen() ->
     {ok, ListenSocket} = gen_tcp:listen(0, [binary, {active, false}, {reuseaddr, true}, {ip, {127, 0, 0, 1}}]),
@@ -31,9 +31,3 @@ close_listen(Socket) ->
 close_server(Socket) ->
     gen_tcp:close(Socket),
     nil.
-
-get_env(Name) ->
-    case os:getenv(binary_to_list(Name)) of
-        false -> {error, nil};
-        Value -> {ok, list_to_binary(Value)}
-    end.

--- a/test/test_container_ffi.erl
+++ b/test/test_container_ffi.erl
@@ -1,121 +1,5 @@
 -module(test_container_ffi).
--export([start_ftp_container/0, start_ftp_active_container/0, start_ftps_container/0,
-         get_ftp_port/1, get_ftp_active_port/1, get_ftps_port/1, get_mapped_port/2, stop_container/1]).
-
--define(IMAGE, "delfer/alpine-ftp-server:latest").
-
-start_ftp_container() ->
-    %% Clean up any stale containers from previous failed runs
-    cmd("docker ps -aq --filter ancestor=" ?IMAGE
-        " | xargs docker rm -f 2>/dev/null; true", 10000),
-    Cmd = "docker run -d"
-        " -e \"USERS=test|test|/home/test\""
-        " -e ADDRESS=127.0.0.1"
-        " -e MIN_PORT=21100"
-        " -e MAX_PORT=21110"
-        " -p 2121:21"
-        " -p 21100-21110:21100-21110"
-        " " ?IMAGE,
-    ContainerId = string:trim(cmd(Cmd, 60000)),
-    wait_for_ready(ContainerId, 30),
-    list_to_binary(ContainerId).
-
-get_ftp_port(_ContainerId) ->
-    2121.
-
-%% Start an FTP container with --network host for active mode testing.
-%% With host networking, the container shares the host's network namespace,
-%% so the FTP server can connect back to the client's listening port on 127.0.0.1.
-%% This only works on Linux (CI uses ubuntu-latest).
-start_ftp_active_container() ->
-    cmd("docker ps -aq --filter ancestor=" ?IMAGE
-        " | xargs docker rm -f 2>/dev/null; true", 10000),
-    Cmd = "docker run -d"
-        " --network host"
-        " -e \"USERS=test|test|/home/test\""
-        " -e ADDRESS=127.0.0.1"
-        " -e MIN_PORT=21100"
-        " -e MAX_PORT=21110"
-        " " ?IMAGE,
-    ContainerId = string:trim(cmd(Cmd, 60000)),
-    wait_for_ready(ContainerId, 30),
-    list_to_binary(ContainerId).
-
-get_ftp_active_port(_ContainerId) ->
-    21.
-
-start_ftps_container() ->
-    %% Clean up any stale containers from previous failed runs
-    cmd("docker ps -aq --filter ancestor=" ?IMAGE
-        " | xargs docker rm -f 2>/dev/null; true", 10000),
-    Cmd = "docker run -d"
-        " -e \"USERS=test|test|/home/test\""
-        " -e ADDRESS=127.0.0.1"
-        " -e MIN_PORT=21100"
-        " -e MAX_PORT=21110"
-        " -p 2122:990"
-        " -p 21100-21110:21100-21110"
-        " " ?IMAGE,
-    ContainerId = string:trim(cmd(Cmd, 60000)),
-    wait_for_ready(ContainerId, 30),
-    setup_ftps(ContainerId),
-    list_to_binary(ContainerId).
-
-get_ftps_port(_ContainerId) ->
-    2122.
-
-get_mapped_port(ContainerId, ContainerPort) ->
-    Output = string:trim(cmd(
-        "docker port " ++ binary_to_list(ContainerId) ++ " "
-        ++ integer_to_list(ContainerPort), 5000)),
-    FirstLine = hd(string:split(Output, "\n")),
-    [_, PortStr] = string:split(FirstLine, ":", trailing),
-    list_to_integer(string:trim(PortStr)).
-
-stop_container(ContainerId) ->
-    cmd("docker rm -f " ++ binary_to_list(ContainerId), 10000),
-    nil.
-
-%% Internal
-
-wait_for_ready(_ContainerId, 0) ->
-    error(container_start_timeout);
-wait_for_ready(ContainerId, Retries) ->
-    timer:sleep(1000),
-    Logs = cmd("docker logs " ++ ContainerId ++ " 2>&1", 5000),
-    case string:find(Logs, "passwd:") of
-        nomatch ->
-            wait_for_ready(ContainerId, Retries - 1);
-        _ ->
-            %% Give vsftpd a moment to finish starting after user setup
-            timer:sleep(1000),
-            ok
-    end.
-
-%% Run a shell command with an explicit timeout (ms).
-%% Uses open_port instead of os:cmd to avoid hangs.
-cmd(Command, Timeout) ->
-    Port = open_port(
-        {spawn, "/bin/sh -c '" ++ escape_single_quotes(Command) ++ "'"},
-        [stream, exit_status, use_stdio, binary]),
-    cmd_collect(Port, [], Timeout).
-
-cmd_collect(Port, Acc, Timeout) ->
-    receive
-        {Port, {data, Data}} ->
-            cmd_collect(Port, [Data | Acc], Timeout);
-        {Port, {exit_status, _}} ->
-            binary_to_list(iolist_to_binary(lists:reverse(Acc)))
-    after Timeout ->
-        catch port_close(Port),
-        binary_to_list(iolist_to_binary(lists:reverse(Acc)))
-    end.
-
-escape_single_quotes(Str) ->
-    lists:flatmap(
-        fun($') -> "'\\''";
-           (C) -> [C]
-        end, Str).
+-export([setup_ftps/1]).
 
 %% FTPS setup: generate a self-signed cert and start a second vsftpd
 %% instance with TLS enabled on port 990 inside the container.
@@ -139,15 +23,41 @@ setup_ftps(ContainerId) ->
         "echo force_local_data_ssl=NO >> /etc/vsftpd/vsftpd_tls.conf && "
         "echo force_local_logins_ssl=NO >> /etc/vsftpd/vsftpd_tls.conf && "
         "echo require_ssl_reuse=NO >> /etc/vsftpd/vsftpd_tls.conf"),
-    cmd("docker exec -d " ++ ContainerId
+    cmd("docker exec -d " ++ binary_to_list(ContainerId)
         ++ " vsftpd"
         ++ " -opasv_min_port=21100"
         ++ " -opasv_max_port=21110"
         ++ " -opasv_address=127.0.0.1"
         ++ " /etc/vsftpd/vsftpd_tls.conf", 5000),
     timer:sleep(2000),
-    ok.
+    nil.
+
+%% Internal
 
 exec(ContainerId, ShellCmd) ->
-    cmd("docker exec " ++ ContainerId
+    cmd("docker exec " ++ binary_to_list(ContainerId)
         ++ " sh -c \"" ++ ShellCmd ++ "\"", 60000).
+
+%% Run a shell command with an explicit timeout (ms).
+cmd(Command, Timeout) ->
+    Port = open_port(
+        {spawn, "/bin/sh -c '" ++ escape_single_quotes(Command) ++ "'"},
+        [stream, exit_status, use_stdio, binary]),
+    cmd_collect(Port, [], Timeout).
+
+cmd_collect(Port, Acc, Timeout) ->
+    receive
+        {Port, {data, Data}} ->
+            cmd_collect(Port, [Data | Acc], Timeout);
+        {Port, {exit_status, _}} ->
+            binary_to_list(iolist_to_binary(lists:reverse(Acc)))
+    after Timeout ->
+        catch port_close(Port),
+        binary_to_list(iolist_to_binary(lists:reverse(Acc)))
+    end.
+
+escape_single_quotes(Str) ->
+    lists:flatmap(
+        fun($') -> "'\\''";
+           (C) -> [C]
+        end, Str).


### PR DESCRIPTION
Now that testcontainers 2.0.0 is finally released, we can finally fully configure containers to achieve the FTP server we need to run this